### PR TITLE
Fix job details redirects | Fix jobs/companies description on jobs/companies details pages

### DIFF
--- a/site/src/routes/(site)/companies/[id]/+page.svelte
+++ b/site/src/routes/(site)/companies/[id]/+page.svelte
@@ -264,7 +264,7 @@
               About {company.name}
             </h2>
             <p class="text-muted leading-relaxed whitespace-pre-line">
-              {company.profile}
+              {@html company.profile}
             </p>
           </div>
         {/if}

--- a/site/src/routes/(site)/companies/[id]/+page.svelte
+++ b/site/src/routes/(site)/companies/[id]/+page.svelte
@@ -263,9 +263,9 @@
               <FileText class="w-5 h-5 text-primary" />
               About {company.name}
             </h2>
-            <p class="text-muted leading-relaxed whitespace-pre-line">
+            <div class="text-muted leading-relaxed whitespace-pre-line">
               {@html company.profile}
-            </p>
+            </div>
           </div>
         {/if}
 

--- a/site/src/routes/(site)/jobs/+page.svelte
+++ b/site/src/routes/(site)/jobs/+page.svelte
@@ -759,7 +759,7 @@
                 style="animation: fade-in-up 0.4s ease forwards; animation-delay: {Math.min(index * 30, 200)}ms; opacity: 0;"
               >
                 <a
-                  href="/jobs/{job.id}"
+                  href="/jobs/{job.id}/"
                   class="block p-4 lg:p-5"
                   aria-label="View details for {job.title} at {job.company_name}"
                 >

--- a/site/src/routes/(site)/jobs/+page.svelte
+++ b/site/src/routes/(site)/jobs/+page.svelte
@@ -759,7 +759,7 @@
                 style="animation: fade-in-up 0.4s ease forwards; animation-delay: {Math.min(index * 30, 200)}ms; opacity: 0;"
               >
                 <a
-                  href="/jobs/{job.slug.replace(/^\/+/, '')}"
+                  href="/jobs/{job.id}"
                   class="block p-4 lg:p-5"
                   aria-label="View details for {job.title} at {job.company_name}"
                 >

--- a/site/src/routes/(site)/jobs/[id]/+page.svelte
+++ b/site/src/routes/(site)/jobs/[id]/+page.svelte
@@ -455,7 +455,7 @@
               <FileText size={18} class="text-primary-600" />
               Job Description
             </h2>
-            <div class="text-muted leading-relaxed whitespace-pre-line">{job.description}</div>
+            <div class="text-muted leading-tight whitespace-pre-line">{@html job.description}</div>
           </div>
         {/if}
 
@@ -622,7 +622,7 @@
 
             {#if job.company_description}
               <p class="text-muted leading-relaxed mb-5 whitespace-pre-line">
-                {job.company_description}
+                {@html job.company_description}
               </p>
             {/if}
 

--- a/site/src/routes/(site)/jobs/[id]/+page.svelte
+++ b/site/src/routes/(site)/jobs/[id]/+page.svelte
@@ -621,9 +621,9 @@
             </h2>
 
             {#if job.company_description}
-              <p class="text-muted leading-relaxed mb-5 whitespace-pre-line">
+              <div class="text-muted leading-relaxed mb-5 whitespace-pre-line">
                 {@html job.company_description}
-              </p>
+              </div>
             {/if}
 
             <div class="space-y-3">


### PR DESCRIPTION
## Fixes:
1. Clicking on job list item on `loclahost:5173/jobs/` will redirect user to detail page using `id` instead of `slug`. Example: `localhost:5173/jobs/593/` instead of `localhost:5173/jobs/592-agriculture-developer/`. This fix will avoid **`404 not found`** errors
---
2. Jobs and companies description use `@html` **Svelte** tag to avoid displaying **HTML** on jobs detils pages
---
3. Company description use `@html` **Svelte** tag to avoid displaying **HTML** on companies details pages
---

Fixes #246 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Company profiles and job descriptions now correctly display formatted content, including supported HTML markup.
- Job listing links now use reliable numeric job IDs, improving navigation to job details.
- Job description text uses more compact line spacing for a cleaner, easier-to-scan reading experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->